### PR TITLE
Implement DLQ reprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Example Spring Boot application written in Kotlin that listens to an AWS SQS
 queue. When a message is received the path to an Excel file is processed using
 Apache POI. If an error occurs the original message is sent to a dead letter
-queue (DLQ) for later reprocessing.
+queue (DLQ). Messages in the DLQ are automatically reprocessed by a scheduled
+task in the same application.
 
 Queue names can be configured in `src/main/resources/application.properties`:
 
@@ -13,4 +14,6 @@ app.sqs.dlq-name=yourDlq
 ```
 
 The listener is implemented in `SqsListenerService` and depends on
-`ExcelProcessor` for the file handling logic.
+`ExcelProcessor` for the file handling logic. The DLQ messages are handled by
+`DlqReprocessorService`, which polls the DLQ periodically. The polling interval
+can be configured using `app.dlq.reprocess-interval` (in milliseconds).

--- a/src/main/kotlin/com/example/demo/DemoApplication.kt
+++ b/src/main/kotlin/com/example/demo/DemoApplication.kt
@@ -2,10 +2,10 @@ package com.example.demo
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import io.awspring.cloud.sqs.annotation.EnableSqs
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
-@EnableSqs
+@EnableScheduling
 class DemoApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/example/demo/sqs/DlqReprocessorService.kt
+++ b/src/main/kotlin/com/example/demo/sqs/DlqReprocessorService.kt
@@ -1,0 +1,35 @@
+package com.example.demo.sqs
+
+import io.awspring.cloud.sqs.operations.SqsTemplate
+import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class DlqReprocessorService(
+    private val excelProcessor: ExcelProcessor,
+    private val sqsTemplate: SqsTemplate,
+    @Value("\${app.sqs.dlq-name}") private val dlqName: String
+) {
+
+    private val logger = LoggerFactory.getLogger(DlqReprocessorService::class.java)
+
+    @Scheduled(fixedDelayString = "\${app.dlq.reprocess-interval:60000}")
+    fun reprocess() {
+        val messageOpt = sqsTemplate.receive { options ->
+            options.queue(dlqName).maxNumberOfMessages(1)
+        }
+
+        messageOpt.ifPresent { message ->
+            val payload = message.payload as String
+            try {
+                excelProcessor.process(payload)
+                Acknowledgement.acknowledge(message)
+            } catch (ex: Exception) {
+                logger.error("Error reprocessing message from DLQ", ex)
+            }
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=demo
 app.sqs.queue-name=yourQueue
 app.sqs.dlq-name=yourDlq
+app.dlq.reprocess-interval=60000

--- a/src/test/kotlin/com/example/demo/DemoApplicationTests.kt
+++ b/src/test/kotlin/com/example/demo/DemoApplicationTests.kt
@@ -1,6 +1,7 @@
 package com.example.demo
 
 import com.example.demo.sqs.ExcelProcessor
+import com.example.demo.sqs.DlqReprocessorService
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,8 +13,12 @@ class DemoApplicationTests {
     @Autowired
     lateinit var excelProcessor: ExcelProcessor
 
+    @Autowired
+    lateinit var dlqReprocessorService: DlqReprocessorService
+
     @Test
     fun contextLoads() {
         assertNotNull(excelProcessor)
+        assertNotNull(dlqReprocessorService)
     }
 }


### PR DESCRIPTION
## Summary
- add scheduled DlqReprocessorService
- enable scheduling in DemoApplication
- document DLQ reprocessing logic
- expose reprocess interval property
- check DlqReprocessorService bean in tests

## Testing
- `gradle test` *(fails: QueueAttributesResolvingException)*

------
https://chatgpt.com/codex/tasks/task_e_6888044fc38c832d95a4a3a463fb8d70